### PR TITLE
mapping interrupts handlers to an array 

### DIFF
--- a/kernel/interrupts_handlers.c
+++ b/kernel/interrupts_handlers.c
@@ -1,10 +1,13 @@
 #include "isr.h"
 
+/* Once installing an ISR for a given interrupt or an IRQ , the installer should call map_handler_interrupt */
+isr handlers[256]={0} ; 
+
 void irq_handler(registers reg ) {
-    // Here irq handlers should be handled , with some sort of array  points to functions for every number interrupt 
+   
 
 
-    /* Send end of interrupt signal to PICs */ 
+    	/* Send end of interrupt signal to PICs */ 
 	/* Checking if interrupt involved the slave */
 
     if(reg.int_no >= 40) { 
@@ -14,11 +17,20 @@ void irq_handler(registers reg ) {
 
 	/* Sending end of interrupt to master */
 	EOI(0x20) ;/* 0x20 port for master*/
+	
+	// Checking if interrupt is installed 
+	// if so , call its handlers 
+	if (handlers[reg.int_no]!=0) handlers[reg.int_no](reg)  ; 
 
     return  ; 
 }
 
 
+void map_handler_interrupt(unsigned int interrupt_number, isr handler) { // mapping interrupts numbers to convenient handlers
+	
+	handlers[interrupt_number] = handler ;  
+
+}
 
 void isr_handler() {
     

--- a/kernel/isr.h
+++ b/kernel/isr.h
@@ -14,4 +14,11 @@ typedef struct registers_struct
 // End of interrupt 
 extern void EOI() ;
 
+// Handlers 
+typedef void (*isr)(registers) ; 
+
+// Call this function to map an interrupt once installed 
+void map_handler_interrupt(unsigned int  Nr_interrupt ,isr handler ) ;
+
+
 #endif


### PR DESCRIPTION
interrupts are mapped into an array of functions with definition isr , now interrupts can be installed calling map_interrupts_handlers .
